### PR TITLE
feat: update file upload to support mulitple files (LeftColumn)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
           <Providers>
             <div className="flex flex-col min-h-screen">
               <Header />
-              <div className="flex-1 ">{children}</div>
+              <div className="flex-grow">{children}</div>
               <Footer />
             </div>
           </Providers>

--- a/app/salary/page.tsx
+++ b/app/salary/page.tsx
@@ -250,8 +250,8 @@ export default function SalaryPage() {
           </TypographyP>
         </div>
         <div className="mt-5 grow md:col-span-1 md:mt-0">
-          <div className="flex flex-col h-full px-4 py-5 space-y-6 bg-white sm:p-6">
-            <div className="relative flex flex-col items-center justify-center flex-1 max-h-full pl-4 mt-1 border-2 border-solid rounded-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-slate-500 sm:text-sm min-h-[24rem]">
+          <div className="flex flex-col h-full px-4 py-5 space-y-6 bg-white sm:p-6 min-h-[24rem]">
+            <div className="relative flex flex-col items-center justify-center flex-1 max-h-full pl-4 mt-1 border-2 border-solid rounded-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-slate-500 sm:text-sm">
               <RightColumn
                 imageIds={imageIds}
                 currentImageIndex={currentImageIndex}

--- a/app/salary/page.tsx
+++ b/app/salary/page.tsx
@@ -186,7 +186,7 @@ export default function SalaryPage() {
                             // transform: `${index * 5}deg`,
                           }}
                         >
-                          <div className="relative flex flex-col items-center justify-center flex-1 max-h-full mt-1 border-2 border-solid rounded-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-slate-500 sm:text-sm">
+                          <div className="relative flex flex-col items-center justify-center flex-1 mt-1 border-2 border-solid rounded-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-slate-500 sm:text-sm">
                             <Image
                               alt="screenshot uploaded by the user"
                               className="object-contain rounded-t-md h-96 w-96 rounded-2xl"
@@ -219,7 +219,7 @@ export default function SalaryPage() {
         </div>
         <div className="mt-5 grow md:col-span-1 md:mt-0">
           <div className="flex flex-col h-full px-4 py-5 space-y-6 bg-white sm:p-6">
-            <div className="relative flex flex-col items-center justify-center flex-1 max-h-full pl-4 mt-1 border-2 border-solid rounded-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-slate-500 sm:text-sm">
+            <div className="relative flex flex-col items-center justify-center flex-1 max-h-full pl-4 mt-1 border-2 border-solid rounded-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-slate-500 sm:text-sm min-h-[24rem]">
               <RightColumn
                 imageId={
                   imageIds ? imageIds[currentImageIndex ?? 0] : undefined

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -5,7 +5,7 @@ import { siteConfig } from "../lib/site-config"
 export function Footer() {
   return (
     <footer className="mt-4 border-t border-t-slate-200 dark:border-t-slate-700">
-      <div className="flex flex-col items-center justify-center gap-4 py-10 md:h-16 md:flex-row md:py-0">
+      <div className="flex flex-col items-center justify-center gap-4 py-4 md:h-16 md:flex-row md:py-0">
         <div className="flex flex-col items-center gap-4 px-4 md:flex-row md:gap-2 ">
           <Laugh className="w-6 h-6" />
           <p className="text-sm leading-loose text-center text-slate-600 dark:text-slate-400 md:text-left">

--- a/pages/api/operations/[operationId].ts
+++ b/pages/api/operations/[operationId].ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import {
+  DocumentProcessorServiceClient,
+  protos,
+} from "@google-cloud/documentai"
+
+// a handler to parse send an image to the google cloud document ai api and persist it in the google cloud storage, then return the parsed data
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const operationId = req.query.operationId as string
+  const client = new DocumentProcessorServiceClient()
+  const name = `projects/852342095963/locations/us/operations/${operationId}`
+
+  const request = new protos.google.longrunning.GetOperationRequest({ name })
+  const [operation] = await client.operationsClient.getOperation(request)
+
+  return res.status(200).json(operation)
+}

--- a/pages/api/operations/[operationId].ts
+++ b/pages/api/operations/[operationId].ts
@@ -9,9 +9,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const operationId = req.query.operationId as string
   const client = new DocumentProcessorServiceClient()
-  const name = `projects/852342095963/locations/us/operations/${operationId}`
+  const name = `projects/852342095963/locations/us/operations/${req.query.operationId}`
 
   const request = new protos.google.longrunning.GetOperationRequest({ name })
   const [operation] = await client.operationsClient.getOperation(request)

--- a/pages/api/process-image.ts
+++ b/pages/api/process-image.ts
@@ -74,7 +74,6 @@ export default async function handler(
     if (!operation || !operation.name) {
       return res.status(500).json({ error: "Operation not found" })
     }
-
     // Wait for operation to complete.
     const batchPromiseResponse = await operation.promise()
     // return the operation name

--- a/pages/api/process-image.ts
+++ b/pages/api/process-image.ts
@@ -77,7 +77,7 @@ export default async function handler(
     if (!operation || !operation.name) {
       return res.status(500).json({ error: "Operation not found" })
     }
-    return res.status(200).json({ operationName: operation.name })
+    return res.status(200).json({ operation })
   } catch (error) {
     console.log("ERROR FETCHING FROM GOOOOOGLE")
     console.dir(error, { depth: 5 })

--- a/pages/api/salaries/[operationId].ts
+++ b/pages/api/salaries/[operationId].ts
@@ -1,0 +1,210 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { Storage } from "@google-cloud/storage"
+
+import { env } from "../../../lib/env/server.mjs"
+import { prisma } from "../../../lib/server/db"
+import { convertCurrencyString } from "../../../lib/server/parsers"
+import { gcsOutputUri } from "../process-image.js"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { operationId } = req.query
+  const operation = await prisma.longRunningOperation.findUnique({
+    include: { images: true },
+    where: {
+      id: operationId as string,
+    },
+  })
+  if (!operation) {
+    return res.status(404).json({ error: "Operation not found" })
+  }
+  if (!operation?.images.length) {
+    return res
+      .status(404)
+      .json({ error: `No images associated with operation id ${operationId}` })
+  }
+  let imgIndex = 0
+
+  // parse the salary data & persist to DB for each image
+  for (const image of operation.images) {
+    // Get the results of the batch process using the operation name to parse the salaryData
+    const bucket = new Storage({
+      projectId: env.GOOGLE_CLOUD_PROJECT_ID,
+      credentials: {
+        client_email: env.GOOGLE_CLOUD_CLIENT_EMAIL,
+        private_key: env.GOOGLE_CLOUD_PRIVATE_KEY,
+      },
+    }).bucket(image.bucketName)
+
+    const file = bucket.file(
+      // subfolder(s) + /0/ + filename
+      `${
+        env.GOOGLE_CLOUD_STORAGE_OUTPUT_PREFIX +
+        operation.lroName.split("/").pop()
+      }/${imgIndex}/${image.id}-0.json` // -0.json is added automatically?
+    )
+    imgIndex++
+
+    const fileDownload = await file.download()
+    const json = JSON.parse(fileDownload[0].toString("utf8"))
+    const salaryData = parseSalaryDataFromText(json.text).map((row) =>
+      row.map(convertCurrencyString)
+    )
+    // Now that we have obtained our parsed result, persist everyting to the database
+    Promise.all([
+      // store the document ai result
+      await prisma.documentProcessResult.create({
+        data: {
+          bucketName: image.bucketName,
+          fileContent: json,
+          publicUrl: file.publicUrl(),
+          textResponse: json.text,
+          filename: file.name,
+          longRunningOperation: {
+            connect: {
+              id: operation.id,
+            },
+          },
+        },
+      }),
+      // store our parsed data (from the result)
+      await prisma.salary.create({
+        data: {
+          data: salaryData,
+          image: {
+            connect: {
+              id: image.id,
+            },
+          },
+        },
+      }),
+    ])
+  }
+  const salaryData = await prisma.salary.findMany({
+    include: { image: true },
+    where: {
+      image: {
+        longRunningOperationId: operation.id,
+      },
+    },
+  })
+  // now return the data
+  return res.status(200).json(salaryData)
+}
+
+// UTIL
+export const parseSalaryDataFromText = (responseText: string) => {
+  console.dir(responseText) // this looks something like this: 'Team Salaries\n2046 CAP\nRAINERS\nA.JUDGE\nC\nOVERALL 84\n2046 CAP PEN.\n
+  // trim unnecessary data
+  const [trimmed, _trailingGarbage] = responseText.split("\nVIEW PLAYER CARD") // the last value is followed by: '$0\nVIEW PLAYER CARD\nSORT\nO BACK\nSAMSUNG\n'
+  console.log("TRIMMED: ", trimmed)
+  // separate the two detected tables
+  const [teamInfo, salaryData] = trimmed.split("\nAll\nR2\n") // this seprates the salary table from the team info stuff (salary cap etc.)
+
+  // we'll not split up the header and body data
+  // note (richard): the delimiter between header & body is the second occurrence of \nNAME
+  const secondNameIndex = salaryData.lastIndexOf("\nNAME\n")
+
+  // now, split headerData
+  const headerRow = salaryData
+    // everything _until_ the second occurrence of \nNAME
+    .substring(0, secondNameIndex)
+    // split it into an array of header cells
+    .split(/\n|\s/)
+
+  // now, split the bodyData
+  const bodyDataString = salaryData
+    // everything _after_ the second occurrence of \nNAME
+    .substring(secondNameIndex + "\nNAME\n".length, salaryData.length)
+
+  const bodyData = bodyDataString
+    // split it into an array of body cells
+    .split(/\n|\s/)
+  // the body data now looks something like this:
+  // [
+  // 'A.Ramsay', 'DT',     '29',     '85',       '6',      '1',
+  // '$58.2M',   '$19.3M', '$12.6M', '$0',       '$0',     '$0',
+  // '$0',       '1180',   'H.Pyne', 'QB',       '29',     '85',
+  // '8',        '4',      '$164M',  '$35.5M', ...
+  // ]
+  // Let's obtain the bodyRows in a proper tuple [][] with as many columns as the headerRow
+
+  // @ts-expect-error this would need to be types as a tuple but would need to fill the remaining array with $0's
+  const bodyRows = []
+  // the below code splits the array into rows, and then cleans up the data in each row
+  // note: a player's name denominates a new row
+  const playerNames = bodyDataString.match(/([A-Z]\.[A-Z]\w+)/g)
+  if (!playerNames) throw new Error("No player names found in body data")
+
+  playerNames.forEach((playerName, index) => {
+    // slice the player's row from the bodyData
+    const row = bodyData.slice(
+      // the index of the player's name determines the _start_ of the row
+      bodyData.indexOf(playerName),
+      // the _end_ of the row is determined by the *next* player's name OR the end of the array
+      Boolean(playerNames[index + 1])
+        ? bodyData.indexOf(playerNames[index + 1])
+        : bodyData.length
+    )
+
+    // now, clean up the row by running the row values through a regex for every column
+    console.log("This row will be cleaned up now:", row)
+    // @ts-expect-error this would need to be types as a tuple but would need to fill the remaining array with $0's
+    const cleanedRow = []
+    row.forEach((rowValue) => {
+      if (cleanedRow.length === headerRow.length) {
+        // early return when we already have enough cells extracted
+        return
+      }
+      const colIndex = cleanedRow.length // we always check the current columns' regex. E.g. without any extraction, we'll check the first regex, after the first extraction we'll use the second regex, and so on.
+      console.assert(
+        rowRegexes[colIndex].test(rowValue),
+        `rowValue (${rowValue}) does not match the regex (${rowRegexes[colIndex]}) for the column ${colIndex}`
+      )
+      // extract only if the value matches the regex
+      if (rowRegexes[colIndex].test(rowValue)) {
+        cleanedRow.push(rowValue)
+      }
+    })
+
+    // we now have the cleanedRow and push that to the bodyRows
+    // @ts-expect-error this would need to be types as a tuple but would need to fill the remaining array with $0's
+    console.log("cleanedRow: ", cleanedRow)
+    // @ts-expect-error this would need to be types as a tuple but would need to fill the remaining array with $0's
+    bodyRows.push(cleanedRow)
+  })
+  // return the data table
+  // @ts-expect-error this would need to be types as a tuple but would need to fill the remaining array with $0's
+  return [headerRow, ...bodyRows]
+}
+
+const rowRegexes = [
+  // regex to match the player name, e.g. R. Wilson
+  /[A-Z]\.[A-Z]\w+/,
+  // regex to match the position abbreviation (MLB, LE, QB, C, etc.)
+  /[A-Z]{1,3}/,
+  // regex to match the age number (haven't seen any player with <20 years old or >40 years old)
+  /[2-3][0-9]/,
+  // regex to match the OVR rating (Haven't seen any player with <40 OVR)
+  /[5-9][0-9]/,
+  // regex to match the contract length (maximum contract length is 7 years + current)
+  /^[1-8]$/,
+  // regex to match the remaining years (maximum contract length is 7 years + current)
+  /^[1-8]$/,
+  // regex to match the total salary amount, $11.5M, $11.5K, $7M, etc.
+  /\$[0-9.]+(M|K)/,
+  // regex to match the total bonus amount as above but also $0
+  /^\$[0-9]+([,\.]{0,1}[0-9]{0,2})(M|K)?$/,
+  // regex to match the salary for the first year, as above
+  /^\$[0-9]+([,\.]{0,1}[0-9]{0,2})(M|K)?$/,
+  // regex to match the salary for the second year, as above
+  /^\$[0-9]+([,\.]{0,1}[0-9]{0,2})(M|K)?$/,
+  // regex to match the salary for the third year as above
+  /^\$[0-9]+([,\.]{0,1}[0-9]{0,2})(M|K)?$/,
+  // regex to match the salary for the fourth year as above
+  /^\$[0-9]+([,\.]{0,1}[0-9]{0,2})(M|K)?$/,
+  // regex to match the salary for the fifth year as above
+  /^\$[0-9]+([,\.]{0,1}[0-9]{0,2})(M|K)?$/,
+]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,39 +11,35 @@ datasource db {
 }
 
 model Image {
-    id              String           @id @default(cuid())
-    filename        String
-    bucketName      String
-    publicUrl       String?
-    gcsUri          String?
-    createdAt       DateTime         @default(now())
-    updatedAt       DateTime         @updatedAt
-    documentProcess DocumentProcess?
-    salary          Salary?
+    id                     String                @id @default(cuid())
+    filename               String
+    bucketName             String
+    publicUrl              String?
+    gcsUri                 String?
+    createdAt              DateTime              @default(now())
+    updatedAt              DateTime              @updatedAt
+    salary                 Salary?
+    LongRunningOperation   LongRunningOperation? @relation(fields: [longRunningOperationId], references: [id])
+    longRunningOperationId String?
 }
 
-model DocumentProcess {
-    id                    String @id @default(cuid())
-    // every process is linked to an image (1:1)
-    imageId               String @unique
-    image                 Image  @relation(fields: [imageId], references: [id])
-    // the request object's data
-    processorResourceName String
-    outputGcsUri          String
-    // the process operation's data
-    operationName         String
+model LongRunningOperation {
+    id      String  @id @default(cuid())
+    // these come from google cloud's long running operation directly
+    lroName String  @unique
+    lroId   String  @unique
+    // every operation can have anywhere from 1 to many images
+    images  Image[]
 
-    createdAt DateTime               @default(now())
-    updatedAt DateTime               @updatedAt
-    // every process has a single response linked (1:1)
-    result    DocumentProcessResult?
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    // every operation have anywhere from 1 to many results
+    documentProcessResults DocumentProcessResult[]
 }
 
 model DocumentProcessResult {
-    id                String          @id @default(cuid())
-    // every result is linked to a single process (1:1)
-    documentProcessId String          @unique
-    documentProcess   DocumentProcess @relation(fields: [documentProcessId], references: [id])
+    id String @id @default(cuid())
 
     filename   String
     bucketName String
@@ -51,6 +47,9 @@ model DocumentProcessResult {
 
     fileContent  Json
     textResponse Json
+
+    longRunningOperationId String?
+    longRunningOperation   LongRunningOperation? @relation(fields: [longRunningOperationId], references: [id])
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt


### PR DESCRIPTION
WIP:
<img width="1344" alt="CleanShot 2023-03-23 at 11 00 09@2x" src="https://user-images.githubusercontent.com/18185649/227168650-c6df45d2-97b9-4a3d-b974-95936a300700.png">

To dos:
- [x] Update File upload component to support multiple files
  - gcs upload as well
- [ ] Update `api/process-image` to handle multiple files (in a batch request still)
  - this already runs with a batch request
  - make it return the data of the document processes instead and let the client poll the backend for updates on this process (avoids Vercel function timeout)
- [ ] Update Table data to display data from multiple requests 
  - extract salary parsing from `api/process-image` to to after the document process was successful (create an endpoint called `api/parse-salary` or something accepting multiple processes
  - return the result with the imageId as the key so that the user can navigate through image + table
- [ ] add imageId navigation buttons to shuffle through images + tables in the last step 